### PR TITLE
Don't promisify mkdirp & rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-spellchecker-provider",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Implement spellcheck provider for electron",
   "scripts": {
     "doc": "esdoc -c ./esdoc.json",

--- a/src/promisify.js
+++ b/src/promisify.js
@@ -1,6 +1,6 @@
 import pify from 'pify';
 
-module.exports = ['fs', 'mkdirp', 'rimraf'].reduce((acc, x) => {
+module.exports = ['fs'].reduce((acc, x) => {
   acc[x] = pify(require(x));
   return acc;
 }, {});


### PR DESCRIPTION
- `rimraf` is listed in `devDependencies`, should not be used at runtime
- neither `mkdirp` nor `rimraf` are used via `src/promisify.js`